### PR TITLE
gradingform_multigraders: Use get_enrolled_users() to improve efficiency

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -61,21 +61,14 @@ class gradingform_multigraders_editform extends moodleform {
         $areaid = required_param('areaid', PARAM_INT);
         $manager = get_grading_manager($areaid);
 
-        $arrUsers = Array();
-        $usersTotal = get_users(false,'',true);
-        for($i=0; $i < $usersTotal/100; ++$i){
-            $dbUsers = get_users(true,'',true,null,'lastname ASC,firstname ASC',
-                $firstinitial='', $lastinitial='', $page=$i*100, $recordsperpage=100, $fields='id,firstname,lastname');
-            foreach($dbUsers as $id => $oUser){
-                if(has_capability('mod/assignment:grade', $manager->get_context(),$id)){
-                    $arrUsers[$id] = $oUser->firstname.' '.$oUser->lastname;
-                }
-            }
+        $context = $manager->get_context();
+        $graders = get_enrolled_users($context, 'mod/assignment:grade', 0, 'u.*', 'u.lastname ASC, u.firstname ASC');
+        foreach ($graders as $grader) {
+            $graders[$grader->id] = fullname($grader);
         }
 
-
-        $select = $form->addElement('select', 'secondary_graders_id_list', get_string('secondary_graders', 'gradingform_multigraders'),
-            $arrUsers);
+        $select = $form->addElement('select', 'secondary_graders_id_list',
+                get_string('secondary_graders', 'gradingform_multigraders'), $graders);
         $select->setMultiple(true);
         $form->addHelpButton('secondary_graders_id_list', 'secondary_graders', 'gradingform_multigraders');
 


### PR DESCRIPTION
Hi Lucian, I've been having an early look at this plugin as we really need something that will enable double blind marking, and this looks potentially very useful. However on our test instance we have over 62000 users, so fetching and iterating over all of them takes a very long time and eventually exhausts the php memory limit. Fortunately Moodle provides a function specifically for this purpose, so this commit will provide a massive efficiency saving, especially for large sites. Cheers, Tony